### PR TITLE
Update container instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ sudo docker run --rm \
 -v $(pwd)/INPUTS/:/INPUTS/ \
 -v $(pwd)/OUTPUTS:/OUTPUTS/ \
 -v <path to license.txt>:/opt/freesurfer/license.txt \
+-v /tmp \
 --user $(id -u):$(id -g) \
 ytzero/synbold-disco:v1.4
 <flags>
@@ -60,6 +61,7 @@ singularity run -e \
 -B $(pwd)/INPUTS/:/INPUTS \
 -B $(pwd)/OUTPUTS/:/OUTPUTS \
 -B <path to license.txt>:/opt/freesurfer/license.txt \
+-v /tmp \
 <path to synbold-disco.sif>
 <flags>
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo docker run --rm \
 -v $(pwd)/INPUTS/:/INPUTS/ \
 -v $(pwd)/OUTPUTS:/OUTPUTS/ \
 -v <path to license.txt>:/opt/freesurfer/license.txt \
--v /tmp \
+-v /tmp:/tmp \
 --user $(id -u):$(id -g) \
 ytzero/synbold-disco:v1.4
 <flags>
@@ -61,7 +61,7 @@ singularity run -e \
 -B $(pwd)/INPUTS/:/INPUTS \
 -B $(pwd)/OUTPUTS/:/OUTPUTS \
 -B <path to license.txt>:/opt/freesurfer/license.txt \
--v /tmp \
+-B /tmp \
 <path to synbold-disco.sif>
 <flags>
 ```


### PR DESCRIPTION
For those running HPC clusters, you may need to bind `/tmp` to your Docker/Singularity/Apptainer invocation, as ANTs uses looks for it by default for `mri_nu_correct`. See related issue here: https://github.com/nipreps/fmriprep/issues/1308

I have confirmed that I ran into the original issue with synbold, and that it is fixed after making this change.